### PR TITLE
Added service file for Raspberry Pi v2.1 camera

### DIFF
--- a/service/camera-streamer-pi219-8MP.service
+++ b/service/camera-streamer-pi219-8MP.service
@@ -1,8 +1,13 @@
+;
+; Official Raspberry Pi v2.1 8MP camera based on the Sony IMX219 chip
+; https://www.raspberrypi.com/products/camera-module-v2/
+;
 [Unit]
 Description=camera-streamer web camera
 After=network.target
 
 [Service]
+ConditionPathExists=/sys/bus/i2c/drivers/imx219/10-0010/video4linux
 ExecStart=/usr/local/bin/camera-streamer \
   -camera-path=/base/soc/i2c0mux/i2c@1/imx219@10 \
   -camera-type=libcamera \
@@ -17,8 +22,6 @@ ExecStart=/usr/local/bin/camera-streamer \
   -camera-low_res_factor=4 \
   ; bump brightness slightly
   -camera-options=brightness=0.1 \
-  ; disable auto-focus
-  -camera-auto_focus=0
 
 DynamicUser=yes
 SupplementaryGroups=video i2c

--- a/service/camera-streamer-pi219-8MP.service
+++ b/service/camera-streamer-pi219-8MP.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=camera-streamer web camera
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/camera-streamer \
+  -camera-path=/base/soc/i2c0mux/i2c@1/imx219@10 \
+  -camera-type=libcamera \
+  -camera-format=YUYV \
+  -camera-width=3280 -camera-height=2464 \
+  -camera-fps=30 \
+  ; use two memory buffers to optimise usage
+  -camera-nbufs=2 \
+  ; the high-res is 1640x1232
+  -camera-high_res_factor=2 \
+  ; the low-res is 820x616
+  -camera-low_res_factor=4 \
+  ; bump brightness slightly
+  -camera-options=brightness=0.1 \
+  ; disable auto-focus
+  -camera-auto_focus=0
+
+DynamicUser=yes
+SupplementaryGroups=video i2c
+Restart=always
+RestartSec=10
+Nice=10
+IOSchedulingClass=idle
+IOSchedulingPriority=7
+CPUWeight=20
+AllowedCPUs=1-2
+MemoryMax=250M
+
+[Install]
+WantedBy=multi-user.target

--- a/service/camera-streamer-pi219-8MP.service
+++ b/service/camera-streamer-pi219-8MP.service
@@ -21,7 +21,7 @@ ExecStart=/usr/local/bin/camera-streamer \
   ; the low-res is 820x616
   -camera-low_res_factor=4 \
   ; bump brightness slightly
-  -camera-options=brightness=0.1 \
+  -camera-options=brightness=0.1
 
 DynamicUser=yes
 SupplementaryGroups=video i2c


### PR DESCRIPTION
Adds a working service file for Pi 2.1 camera users (or clone cameras using the IMX219 chip).