### PR TITLE
[webrtc] device/libcamera: fix libcamera::Span API breakage

### DIFF
--- a/device/libcamera/device.cc
+++ b/device/libcamera/device.cc
@@ -123,7 +123,7 @@ void libcamera_device_close(device_t *dev)
 int libcamera_device_set_fps(device_t *dev, int desired_fps)
 {
   int64_t frame_time = 1000000 / desired_fps;
-  dev->libcamera->controls.set(libcamera::controls::FrameDurationLimits, { frame_time, frame_time });
+  dev->libcamera->controls.set(libcamera::controls::FrameDurationLimits, libcamera::Span<const int64_t, 2>({ frame_time, frame_time }));
   return 0;
 }
 


### PR DESCRIPTION
After upgrading from the July, 2022 releases of Raspberry Pi's libcamera packages to the Aug, 2022 releases, compilation fails with:

```
g++ -std=c++17 -MMD -Werror -Wall -g -I/tmp/camera-streamer -D_GNU_SOURCE -DUSE_FFMPEG -DUSE_LIBCAMERA -I/usr/include/libcamera -DUSE_RTSP -I/usr/include/liveMedia -I/usr/include/groupsock -I/usr/include/BasicUsageEnvironment -I/usr/include/UsageEnvironment -DUSE_LIBDATACHANNEL -Ithird_party/libdatachannel/include -Ithird_party/libdatachannel/deps/json/include -c -o device/libcamera/device.o device/libcamera/device.cc
In file included from device/libcamera/libcamera.hh:22,
                 from device/libcamera/device.cc:2:
/usr/include/libcamera/libcamera/controls.h: In instantiation of 'void libcamera::ControlList::set(const libcamera::Control<T>&, const std::initializer_list<_Up>&) [with T = libcamera::Span<const long int, 2>; V = long int]':
device/libcamera/device.cc:126:100:   required from here
/usr/include/libcamera/libcamera/controls.h:403:14: error: no matching function for call to 'libcamera::ControlValue::set<libcamera::Span<const long int, 2> >(libcamera::Span<const long int, 18446744073709551615>)'
  403 |   val->set<T>(Span<const typename std::remove_cv_t<V>>{ value.begin(), value.size() });
      |   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libcamera/libcamera/controls.h:178:7: note: candidate: 'template<class T, typename std::enable_if<((! libcamera::details::is_span<U>::value) && (! std::is_same<std::__cxx11::basic_string<char>, typename std::remove_cv< <template-parameter-1-1> >::type>::value)), std::nullptr_t>::type <anonymous> > void libcamera::ControlValue::set(const T&)'
  178 |  void set(const T &value)
      |       ^~~
/usr/include/libcamera/libcamera/controls.h:178:7: note:   template argument deduction/substitution failed:
/usr/include/libcamera/libcamera/controls.h:177:30: error: no type named 'type' in 'struct std::enable_if<false, std::nullptr_t>'
  177 |            std::nullptr_t> = nullptr>
      |                              ^~~~~~~
/usr/include/libcamera/libcamera/controls.h:190:7: note: candidate: 'template<class T, typename std::enable_if<(libcamera::details::is_span<U>::value || std::is_same<std::__cxx11::basic_string<char>, typename std::remove_cv< <template-parameter-1-1> >::type>::value), std::nullptr_t>::type <anonymous> > void libcamera::ControlValue::set(const T&)'
  190 |  void set(const T &value)
      |       ^~~
/usr/include/libcamera/libcamera/controls.h:190:7: note:   template argument deduction/substitution failed:
/usr/include/libcamera/libcamera/controls.h:403:14: note:   cannot convert 'libcamera::Span<const long int, 18446744073709551615>((& value)->std::initializer_list<long int>::begin(), (& value)->std::initializer_list<long int>::size())' (type 'libcamera::Span<const long int, 18446744073709551615>') to type 'const libcamera::Span<const long int, 2>&'
  403 |   val->set<T>(Span<const typename std::remove_cv_t<V>>{ value.begin(), value.size() });
      |   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After introducing this change (see raspberrypi/libcamera-apps PR 342), it works with both versions mentioned below:

```
$ apt list --installed
libcamera-apps/now 0~git20220707+35266e8-1 arm64 [installed,upgradable to: 0~git20220830+1bf0cca-1]
libcamera-dev/now 0~git20220705+f30ad033-1 arm64 [installed,upgradable to: 0~git20220826+3fad116f-1]
libcamera-tools/now 0~git20220705+f30ad033-1 arm64 [installed,upgradable to: 0~git20220826+3fad116f-1]
libcamera0/now 0~git20220705+f30ad033-1 arm64 [installed,upgradable to: 0~git20220826+3fad116f-1]
```