### PR TITLE
fix: use current url to connect webrtc preview to server

### DIFF
--- a/html/webrtc.html
+++ b/html/webrtc.html
@@ -73,7 +73,7 @@
         const urlSearchParams = new URLSearchParams(window.location.search);
         const params = Object.fromEntries(urlSearchParams.entries());
 
-        fetch('/webrtc', {
+        fetch(window.location.href, {
           body: JSON.stringify({
               type: 'request',
               res: params.res
@@ -109,7 +109,7 @@
         }).then(function(answer) {
           var offer = pc.localDescription;
 
-          return fetch('/webrtc', {
+          return fetch(window.location.href, {
             body: JSON.stringify({
                 type: offer.type,
                 id: pc.remote_pc_id,


### PR DESCRIPTION
This PR should fix the `/webrtc` preview of the camera-streamer. Before, it was a hard fetch to `/webrtc`, but this didn't work with the standard mainsail webcam reverse proxy.

Tested both URLs:
- http://<ip>/webcam/webrtc
- http://<ip>:8080/webrtc

Signed-off-by: Stefan Dej <meteyou@gmail.com>