### PR TITLE
libcamera: fix compilation errors for libcamera v0.3.2+rpt20241119

### DIFF
--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -359,6 +359,7 @@ static libcamera::Size libcamera_parse_size(const char *value)
   return libcamera::Size();
 }
 
+#if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR > 3 && LIBCAMERA_VERSION_PATCH >= 2 // Support for older libcamera versions
 static libcamera::Point libcamera_parse_point(const char *value)
 {
   static const char *POINT_PATTERNS[] =
@@ -379,6 +380,7 @@ static libcamera::Point libcamera_parse_point(const char *value)
 
   return libcamera::Point();
 }
+#endif
 
 template<typename T, typename F>
 static bool libcamera_parse_control_value(libcamera::ControlValue &control_value, const char *value, const F &fn)


### PR DESCRIPTION
Fixes #161, #162 and #164
This PR adds a default case to throw an error during runtime instead of compilation, if a `ControlType` is not implemented yet.

This also adds parsing for the new [`ControlTypePoint`](https://github.com/raspberrypi/libcamera/commit/200d535ca85f23e6c562335c5d9badb5be4db28f) added with libcamera [v0.3.2+rpt20241119](https://github.com/raspberrypi/libcamera/releases/tag/v0.3.2%2Brpt20241119).

This might break compilation for libcamera [v0.3.2+rpt20240927](https://github.com/raspberrypi/libcamera/releases/tag/v0.3.2%2Brpt20240927) and [v0.3.2+rpt20241119](https://github.com/raspberrypi/libcamera/releases/tag/v0.3.2%2Brpt20241119).