### PR TITLE
fix: fix return type of libcamera_parse_point

### DIFF
--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -384,7 +384,7 @@ static std::pair<libcamera::Size, const char*> libcamera_parse_size(const char *
 }
 
 #if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR > 3 && LIBCAMERA_VERSION_PATCH >= 2 // Support for older libcamera versions
-static libcamera::Point libcamera_parse_point(const char *value)
+static std::pair<libcamera::Point, const char*> libcamera_parse_point(const char *value)
 {
   static const char *POINT_PATTERNS[] =
   {
@@ -403,7 +403,7 @@ static libcamera::Point libcamera_parse_point(const char *value)
     }
   }
 
-  return std::make_pair(libcamera::Point(), NULL);
+  return std::make_pair(libcamera::Point(), (const char*)NULL);
 }
 #endif
 


### PR DESCRIPTION
In https://github.com/ayufan/camera-streamer/pull/180 the return types of the option parsers got changed. `libcamera_parse_point` got changed too, but the return type did not get adjusted.