### PR TITLE
fix: set cors for every response

### DIFF
--- a/util/http/http_methods.c
+++ b/util/http/http_methods.c
@@ -18,8 +18,7 @@ void http_write_response(
   fprintf(stream, "Content-Type: %s\r\n", content_type ? content_type : "text/plain");
   if (content_length > 0)
     fprintf(stream, "Content-Length: %d\r\n", content_length);
-  if (!status || strstr(status, "200 OK") == status)
-    fprintf(stream, "Access-Control-Allow-Origin: *\r\n");
+  fprintf(stream, "Access-Control-Allow-Origin: *\r\n");
   fprintf(stream, "\r\n");
   if (body) {
     fwrite(body, 1, content_length, stream);


### PR DESCRIPTION
Missing CORS header can result in wrong errors on the client application, if the client is not on the same host as the server. An example setup would be Mainsail hosted locally for testing and camera-streamer hosted on a Pi.

On the screenshot you can see a 500 status code thrown by an unavailable STUN server. Someone should expect a response with status code 500 and a body containing `Not complete` from the server. Instead you get a `TypeError` in the client, as the response could not get fetched because of the missing CORS header.

<img width="1863" height="899" alt="grafik" src="https://github.com/user-attachments/assets/ef1b6d64-3fd6-4062-a945-aaadc45ebffe" />

Adding CORS to each response should not be harmful and allows the processing of the whole response, even if the request was not successful.