### PR TITLE
links: detect stale only if there are enqueued buffers

### DIFF
--- a/device/links.c
+++ b/device/links.c
@@ -96,7 +96,7 @@ static bool links_enqueue_capture_buffers(buffer_list_t *capture_list, int *time
   buffer_t *capture_buf = NULL;
   uint64_t now_us = get_monotonic_time_us(NULL, NULL);
 
-  if (now_us - capture_list->last_enqueued_us > STALE_TIMEOUT_US && capture_list->dev->output_list == NULL) {
+  if (now_us - capture_list->last_enqueued_us > STALE_TIMEOUT_US && buffer_list_count_enqueued(capture_list) > 0 && capture_list->dev->output_list == NULL) {
     LOG_INFO(capture_list, "Stale detected. Restarting streaming...");
     buffer_list_set_stream(capture_list, false);
     buffer_list_set_stream(capture_list, true);


### PR DESCRIPTION
Taking advantage of the end-of-year holidays, I wanted to try to fix a long-standing bug that plagues the OctoPrint 3D printing community, for which multiple issues have been opened that I believe share the same root cause:

- #90
- #94
- #144

I know this PR only adds one condition to an if statement, but since this isn't my project and I'm not a C/C++ developer, it took me about 10 hours of debugging to understand how camera-streamer works and find the root cause. Following the execution flow across multiple threads and understanding the pipeline from camera capture to HTTP streaming wasn't easy. Please be kind!

## The fix contained in this PR

Stale detection is a camera-streamer mechanism implemented in commit https://github.com/ayufan/camera-streamer/commit/9c3414a65380d6174a8d59e82ebe487c66e4fbaa and is designed to restart the camera if it's no longer filling the enqueued buffers (which have been sent to v4l2/libcamera) for a period of time defined in the [`STALE_TIMEOUT_US`](https://github.com/ayufan/camera-streamer/blob/de94871d91daac5f16b550856bf286129a099f1d/device/links.c#L12) constant (1000 seconds, ~16 minutes).

When there are no clients watching the stream, to save resources, the [links_process_paused](https://github.com/ayufan/camera-streamer/blob/de94871d91daac5f16b550856bf286129a099f1d/device/links.c#L67) function [pauses](https://github.com/ayufan/camera-streamer/blob/de94871d91daac5f16b550856bf286129a099f1d/device/links.c#L90) the camera and stops enqueuing buffers (unless `--camera-force_active` parameter is being used).

I discovered that stale detection has a bug: every time the system returns from a pause longer than `STALE_TIMEOUT_US`, a stale detection is incorrectly triggered, even though the camera is not actually stale.

This happens because the condition that detects staleness is insufficient:
https://github.com/ayufan/camera-streamer/blob/de94871d91daac5f16b550856bf286129a099f1d/device/links.c#L99-L103

When a client reconnects after a pause and reaching this condition, `last_enqueued_us` is old (because it dates back to the last enqueued buffer before the pause), but the enqueued buffer list is empty (all buffers were dequeued during the pause).
In this PR, I propose adding `&& buffer_list_count_enqueued(capture_list) > 0` to the condition, to prevent triggering stale detection if there are no enqueued buffers, which is exactly the case when just returning from a pause. This should fix #90, fix #94, fix #144.

The reason users in the related issues get the HTTP 500 "No frames" error is that the camera cannot provide a frame within 2 seconds ([`DEFAULT_BUFFER_LOCK_GET_TIMEOUT`](https://github.com/ayufan/camera-streamer/blob/de94871d91daac5f16b550856bf286129a099f1d/device/buffer_lock.h#L37)) because v4l2/libcamera is restarting it due to the erroneously triggered stale detection. Indeed, the issues mention waiting some time (16 minutes, `STALE_TIMEOUT_US`) without watching the stream for the bug to occur.

## Further work needed

The fix I'm proposing alone doesn't completely eliminate the race condition between [`buffer_lock_get`](https://github.com/ayufan/camera-streamer/blob/de94871d91daac5f16b550856bf286129a099f1d/device/buffer_lock.c#L96) and the stale stream restarting: if a client connects while a legitimate stale restart is in progress, they will still get the HTTP 500 error because the camera is rebooting.
However, this fix makes the situation much less frequent by ensuring stale detection only triggers when actually needed, rather than every time the system resumes from a pause.
This is why I think relaxing `DEFAULT_BUFFER_LOCK_GET_TIMEOUT` (perhaps to 3-5 seconds) would also help. My cheap Chinese USB webcam on a Raspberry Pi 4 B takes just under 3 seconds (but still more than 2) to provide the first frame after a restart.

I'm also not sure if `STALE_TIMEOUT_US` should be reconsidered, as it seems like an odd value. Have there been any real-world cases where the webcam was actually stale? Is there a reason it's set to 16 minutes?

Perhaps we could consider allowing both `DEFAULT_BUFFER_LOCK_GET_TIMEOUT` and `STALE_TIMEOUT_US` values to be configurable via command parameters instead of hardcoding them; what do you think about that?