### PR TITLE
Add build-deb script and fix trixie builds

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_VERSION
 ARG DOCKER_REPO
 FROM --platform=linux/${DOCKER_ARCH} ${DOCKER_REPO}debian:${DEBIAN_VERSION} AS build_env
 
-RUN apt-get -y update && apt-get -y install gnupg2
+RUN apt-get -y update && apt-get -y install gnupg2 wget
 
 # Add RPI packages (the whole base system, since RPI ships its own GCC)
 ARG DEBIAN_VERSION
@@ -11,8 +11,12 @@ ARG BUILD_TYPE="generic"
 RUN [ "$BUILD_TYPE" != "raspi" ] || \
   ( \
     ( [ "$(dpkg --print-architecture)" != "armhf" ] || echo "deb http://raspbian.raspberrypi.org/raspbian/ $DEBIAN_VERSION main contrib non-free rpi" > /etc/apt/sources.list ) && \
-    gpg --keyserver keyserver.ubuntu.com --recv-keys 9165938D90FDDD2E 82B129927FA3303E && \
-    gpg --export 9165938D90FDDD2E 82B129927FA3303E > /etc/apt/trusted.gpg.d/raspi.gpg && \
+    cd /tmp && \
+    wget "http://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2025.1+rpt1_all.deb" && \
+    echo "2e727149d7acb8cc7f604e66d0049161039c8aa1eaf1175e54f9e69d963d60e4  raspberrypi-archive-keyring_2025.1+rpt1_all.deb" | sha256sum -c && \
+    wget "https://archive.raspbian.org/raspbian/pool/main/r/raspbian-archive-keyring/raspbian-archive-keyring_20120528.4_all.deb" && \
+    echo "eb2bc175ecfad128ece8222b42eefabd0a2846afd14f3af04364f4a047cbc88f  raspbian-archive-keyring_20120528.4_all.deb" | sha256sum -c && \
+    dpkg -i *.deb && \
     echo "deb http://archive.raspberrypi.org/debian/ $DEBIAN_VERSION main" > /etc/apt/sources.list.d/raspi.list && \
     apt-get -y update && \
     apt-get -y install libcamera-dev liblivemedia-dev \

--- a/.github/ci/build-deb
+++ b/.github/ci/build-deb
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <generic|raspi> <bookworm|trixie> [amd64|arm32v7|arm64v8]"
+  exit 1
+fi
+
+docker_image="deb_make"
+
+export BUILD_TYPE="raspi"
+if [[ -n "$1" ]]; then
+  export BUILD_TYPE="$1"
+fi
+shift
+
+export DEBIAN_VERSION="bookworm"
+if [[ -n "$1" ]]; then
+  DEBIAN_VERSION="$1"
+  docker_image="${docker_image}_${1}"
+fi
+shift
+
+arch=${1:-$(dpkg --print-architecture)}
+shift
+
+case "$arch" in
+  amd64)
+    export DOCKER_ARCH="amd64"
+    export DOCKER_REPO="amd64/"
+    ;;
+
+  armhf|arm32v7)
+    export DOCKER_ARCH="arm/v7"
+    export DOCKER_REPO="arm32v7/"
+    ;;
+
+  arm64|arm64v8)
+    export DOCKER_ARCH="arm64/v8"
+    export DOCKER_REPO="arm64v8/"
+    ;;
+
+  *)
+    echo "Unsupported architecture: $arch"
+    exit 1
+    ;;
+esac
+
+PWD=$(pwd)
+ROOT=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd)
+
+set -xeo pipefail
+
+if [[ -z "$GIT_VERSION" ]]; then
+  GIT_VERSION=$(git describe --tags)
+fi
+
+DOCKER_BUILDKIT=1 docker build \
+  --tag "$docker_image" \
+  --target deb_make \
+  --file .github/ci/Dockerfile \
+  --build-arg DOCKER_ARCH \
+  --build-arg DOCKER_REPO \
+  --build-arg DEBIAN_VERSION \
+  --build-arg BUILD_TYPE \
+  --build-arg GIT_VERSION \
+  .
+
+docker rm -f "$docker_image" || true
+docker create --name "$docker_image" "$docker_image"
+trap 'docker rm -f "$docker_image" || true' EXIT
+docker cp "$docker_image":/deb/. deb/


### PR DESCRIPTION
- Add `build-deb` helper script for building Debian packages via Docker
- Support multiple architectures (amd64, arm32v7, arm64v8) and Debian versions (bookworm, trixie)
- Fix Raspberry Pi repository for trixie by marking as trusted (SHA1 signatures rejected by `sqv` since 2026-02-01)
