### PR TITLE
Increase DEFAULT_BUFFER_LOCK_GET_TIMEOUT to 3s

### DIFF
--- a/device/buffer_lock.h
+++ b/device/buffer_lock.h
@@ -34,7 +34,7 @@ typedef struct buffer_lock_s {
 } buffer_lock_t;
 
 #define DEFAULT_BUFFER_LOCK_TIMEOUT 16 // ~60fps
-#define DEFAULT_BUFFER_LOCK_GET_TIMEOUT 2000 // 2s
+#define DEFAULT_BUFFER_LOCK_GET_TIMEOUT 3000 // 3s
 
 #define DEFINE_BUFFER_LOCK(_name, _timeout_ms) buffer_lock_t _name = { \
     .name = #_name, \


### PR DESCRIPTION
This PR increases the [`DEFAULT_BUFFER_LOCK_GET_TIMEOUT`](https://github.com/ayufan/camera-streamer/blob/d4a8ea98a57b6b199ca405dd656e19efe3e62fed/device/buffer_lock.h#L37) constant to 3 seconds to prevent the HTTP 500 "No frames" error when stale detection triggers and restarts the camera.

3 seconds is sufficient to allow the first frame to be served after restart with the 3 cheap USB cameras I tested with. I have no idea if more is needed for poorer cameras.

Further details are available in the discussion in PR #200 thread.