### PR TITLE
fix: fix runtime error for libcamera0.7

### DIFF
--- a/device/libcamera/buffer.cc
+++ b/device/libcamera/buffer.cc
@@ -80,7 +80,7 @@ int libcamera_buffer_enqueue(buffer_t *buf, const char *who)
   auto const &camera = buf->buf_list->dev->libcamera->camera;
 
   request->reuse(libcamera::Request::ReuseBuffers);
-  request->controls() = std::move(buf->buf_list->dev->libcamera->controls);
+  request->controls().merge(buf->buf_list->dev->libcamera->controls);
 
   if (camera->queueRequest(buf->libcamera->request.get()) < 0) {
     LOG_ERROR(buf, "Can't queue buffer.");

--- a/device/libcamera/buffer.cc
+++ b/device/libcamera/buffer.cc
@@ -80,7 +80,10 @@ int libcamera_buffer_enqueue(buffer_t *buf, const char *who)
   auto const &camera = buf->buf_list->dev->libcamera->camera;
 
   request->reuse(libcamera::Request::ReuseBuffers);
-  request->controls().merge(buf->buf_list->dev->libcamera->controls);
+  request->controls().merge(
+    buf->buf_list->dev->libcamera->controls,
+    libcamera::ControlList::MergePolicy::OverwriteExisting
+  );
 
   if (camera->queueRequest(buf->libcamera->request.get()) < 0) {
     LOG_ERROR(buf, "Can't queue buffer.");


### PR DESCRIPTION
Fixes #206

In libcamera0.7 they made some changes, including being stricter on how to modify `Request::controls()`.
https://github.com/raspberrypi/libcamera/commit/310cd8bc0756717cde97fe5b083926f6d6931f58

This PR fixes the error by using the `merge` operation, instead of an assignment overwriting the original `Request::cotrols()`.