### PR TITLE
fix(libcamera): drop MergePolicy arg for Debian Trixie libcamera ABI

### DIFF
--- a/device/libcamera/buffer.cc
+++ b/device/libcamera/buffer.cc
@@ -81,8 +81,7 @@ int libcamera_buffer_enqueue(buffer_t *buf, const char *who)
 
   request->reuse(libcamera::Request::ReuseBuffers);
   request->controls().merge(
-    buf->buf_list->dev->libcamera->controls,
-    libcamera::ControlList::MergePolicy::OverwriteExisting
+    buf->buf_list->dev->libcamera->controls
   );
 
   if (camera->queueRequest(buf->libcamera->request.get()) < 0) {


### PR DESCRIPTION
## Summary

On Debian 13 (Trixie), the system-packaged libcamera does not expose the
two-argument `ControlList::merge(other, MergePolicy)` overload, so
`device/libcamera/buffer.cc` fails to compile.

This patch drops the explicit `MergePolicy::OverwriteExisting` argument,
falling back to the single-argument form which is present in both the
Trixie-packaged libcamera and in the rpt-suffixed Raspberry Pi builds.
`OverwriteExisting` is the default merge behavior in the single-argument
overload, so semantics are preserved on platforms where the two-argument
form is available.

## Tested on

- Debian 13 (Trixie), aarch64, BTT CB1 on Manta M4P
- Camera: Raspberry Pi Camera Module via libcamera
- Build: clean, runtime: streams at 1280x720 / 15fps with no regression

## Notes

- Affects only the libcamera device backend (CSI cameras); USB / V4L2 path
  is unchanged.
- One-line ABI-compat fix; underlying merge semantics are unchanged.
- Related to broader libcamera version compatibility (#137, #156).